### PR TITLE
Match exact userID in GetUsers function

### DIFF
--- a/e2e_suite_test.go
+++ b/e2e_suite_test.go
@@ -545,6 +545,7 @@ var (
 
 	testUsers = []map[string]interface{}{
 		{"userId": "user1", "firstName": "user", "lastName": "one", "emailAddress": "user1@example.com", "status": "active", "roles": []string{"nx-anonymous"}, "password": "user1Password"},
+		{"userId": "user12", "firstName": "user", "lastName": "one", "emailAddress": "user12@example.com", "status": "active", "roles": []string{"nx-anonymous"}, "password": "user12Password"},
 	}
 
 	testRoles = []map[string]interface{}{

--- a/main.go
+++ b/main.go
@@ -315,10 +315,22 @@ func (p *ProxyState) GetUsers(userID *string) ([]NexusUser, error) {
 		body, _ := ioutil.ReadAll(res.Body)
 		return nil, fmt.Errorf("GET %s: %s - %s", &getUser, res.Status, string(body))
 	}
-	result := make([]NexusUser, 0, 1)
-	err = json.NewDecoder(res.Body).Decode(&result)
+	tmpResult := make([]NexusUser, 0, 1)
+	err = json.NewDecoder(res.Body).Decode(&tmpResult)
 	if err != nil {
 		return nil, err
+	}
+	// Nexus API filters results by prefix instead of exact match
+	// This ensures that the user returned is the user requested by userID variable
+	result := make([]NexusUser, 0, 1)
+	if userID != nil {
+		for _, user := range tmpResult {
+			if user.UserID == *userID {
+				result = append(result, user)
+			}
+		}
+	} else {
+		result = tmpResult
 	}
 	if len(result) == 0 {
 		return nil, nil


### PR DESCRIPTION
Nexus users API (`service/rest/v1/security/users?userId=%s`) searches for users by prefix instead of exact match, this can return more than an user, i.e. (`user1`, `user11`, `user111`...) will be returned if searching for `user1`.

This change ensures that only `user1` when it is requested to `GetUsers` function.